### PR TITLE
Make compatible with V8

### DIFF
--- a/src/App_Plugins/our.umbraco.imagecolorpicker/ImageColorPicker.Controller.js
+++ b/src/App_Plugins/our.umbraco.imagecolorpicker/ImageColorPicker.Controller.js
@@ -22,7 +22,19 @@
   $scope.getMediaId = function (alias) {
 
     if (editorState.current) {
-      var tabs = editorState.current.tabs;
+      var tabs = [];
+      
+      if(editorState.current.variants) {
+        // V8 tabs from active variant
+        tabs = _.find(editorState.current.variants, function(v) {
+                  return v.active;
+                }).tabs; 
+      }
+      else {
+        // V7
+        tabs = editorState.current.tabs;
+      }
+      
       var id = null;
       var prop = null;
 
@@ -57,7 +69,7 @@
         var image = new Image();
         image.src = $scope.imageSrc;
 
-        $(image).load(function () {
+        $(image).on('load', function () {
 
           //set the height either from configuration or defaults
           if ($scope.model.config.width && $scope.model.config.height) {


### PR DESCRIPTION
2 small changes to make it compatible with Umbraco V8

In 8 tabs are not stored on the current editorState but on the variants property. So updated the code to get them from the active variant when there is a variants property on the editorState.

jQuery load is deprecated in the version used in V8. So updated that as well.

I did not test my changes on V7.